### PR TITLE
fix(new-tracks): improve toggle switch contrast in light mode

### DIFF
--- a/src/features/new-tracks/components/NewTracksCarousel.tsx
+++ b/src/features/new-tracks/components/NewTracksCarousel.tsx
@@ -73,7 +73,7 @@ export function NewTracksCarousel({ onSelectArtist }: NewTracksCarouselProps) {
             id="hide-reposts"
             checked={hideReposts}
             onCheckedChange={(checked) => useSettingsStore.getState().setHideReposts(checked)}
-            className="h-4 w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input [&_span]:h-3 [&_span]:w-3"
+            className="h-4 w-7 data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted-foreground/30 [&_span]:h-3 [&_span]:w-3"
           />
           <span className="text-xs text-muted-foreground">
             {t('newTracks.hideReposts')}


### PR DESCRIPTION
## Summary
- Replace `bg-input` with `bg-muted-foreground/30` for the unchecked state of the "Hide reposts" toggle switch
- In light mode, `--input` (90% lightness) was nearly invisible against `--background` (98% lightness) — only 8% difference
- `muted-foreground/30` provides clear contrast in both light and dark themes

Closes #6

## Test plan
- [ ] Open app in **light mode** — verify the unchecked toggle switch track is clearly visible
- [ ] Toggle the switch on/off — verify checked state (primary color) still looks correct
- [ ] Switch to **dark mode** — verify the toggle remains visible in both states

🤖 Generated with [Claude Code](https://claude.com/claude-code)