### PR TITLE
fix(rekordbox): handle NULL playlist names in Rekordbox 7 databases

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -21,9 +21,7 @@ fi
 
 if [ "$frontend_changed" -eq 1 ]; then
   echo "pre-commit: running frontend checks"
-  if [ -n "$frontend_ts_files" ]; then
-    printf '%s\n' "$frontend_ts_files" | xargs npx eslint --max-warnings=0 --
-  fi
+  npm run lint
   npm run typecheck
 fi
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,11 @@ export default [
         ...globals.browser,
         ...globals.es2021,
         React: 'readonly',
+        MediaSessionPlaybackState: 'readonly',
+        MediaSessionAction: 'readonly',
+        MediaSessionActionHandler: 'readonly',
+        MediaImage: 'readonly',
+        MediaMetadata: 'readonly',
       },
     },
     plugins: {
@@ -50,7 +55,7 @@ export default [
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
       'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
+      'react-hooks/exhaustive-deps': 'error',
       'no-unused-vars': 'off',
     },
     settings: {

--- a/src-tauri/src/commands/rekordbox.rs
+++ b/src-tauri/src/commands/rekordbox.rs
@@ -221,7 +221,7 @@ pub fn export_to_rekordbox(
 
     ctx.handle_result((|| -> Result<ExportResult, RekordboxError> {
         let mut session = ctx.open_session()?;
-        let infrabooth_folder = session.init_infrabooth_folder()?;
+        session.init_infrabooth_folder()?;
 
         let target_parent_id = parent_folder_id.as_deref().unwrap_or("root");
         let target_playlist_name = playlist_name.as_deref().unwrap_or(ALL_TRACKS_PLAYLIST_NAME);

--- a/src-tauri/src/commands/rekordbox.rs
+++ b/src-tauri/src/commands/rekordbox.rs
@@ -273,9 +273,23 @@ pub fn list_rekordbox_playlists(manual_db_path: Option<String>, _app: tauri::App
 #[tauri::command]
 #[specta::specta]
 pub fn get_rekordbox_playlist_tree(manual_db_path: Option<String>, _app: tauri::AppHandle) -> Result<Vec<RekordboxTreeNode>, ErrorResponse> {
-    let rb_config = resolve_rekordbox_config(manual_db_path)?;
-    let db = database::RekordboxDatabase::open(&rb_config).map_err(ErrorResponse::from)?;
-    playlist::get_playlist_tree(&db).map_err(ErrorResponse::from)
+    log::info!("[rekordbox] get_rekordbox_playlist_tree: manual_db_path={:?}", manual_db_path);
+    let rb_config = resolve_rekordbox_config(manual_db_path).map_err(|e| {
+        log::error!("[rekordbox] Config resolution failed: {} (code={})", e.message, e.code);
+        e
+    })?;
+    log::info!("[rekordbox] Config resolved: db_path={:?}", rb_config.db_path);
+    let db = database::RekordboxDatabase::open(&rb_config).map_err(|e| {
+        log::error!("[rekordbox] Database open failed: {}", e);
+        ErrorResponse::from(e)
+    })?;
+    log::info!("[rekordbox] Database opened successfully");
+    let nodes = playlist::get_playlist_tree(&db).map_err(|e| {
+        log::error!("[rekordbox] Playlist tree query failed: {}", e);
+        ErrorResponse::from(e)
+    })?;
+    log::info!("[rekordbox] Playlist tree loaded: {} nodes", nodes.len());
+    Ok(nodes)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/rekordbox.rs
+++ b/src-tauri/src/commands/rekordbox.rs
@@ -223,7 +223,7 @@ pub fn export_to_rekordbox(
         let mut session = ctx.open_session()?;
         let infrabooth_folder = session.init_infrabooth_folder()?;
 
-        let target_parent_id = parent_folder_id.as_deref().unwrap_or(&infrabooth_folder.id);
+        let target_parent_id = parent_folder_id.as_deref().unwrap_or("root");
         let target_playlist_name = playlist_name.as_deref().unwrap_or(ALL_TRACKS_PLAYLIST_NAME);
         let pl = session.find_or_create_playlist(target_playlist_name, target_parent_id)?;
 

--- a/src-tauri/src/commands/rekordbox.rs
+++ b/src-tauri/src/commands/rekordbox.rs
@@ -273,23 +273,9 @@ pub fn list_rekordbox_playlists(manual_db_path: Option<String>, _app: tauri::App
 #[tauri::command]
 #[specta::specta]
 pub fn get_rekordbox_playlist_tree(manual_db_path: Option<String>, _app: tauri::AppHandle) -> Result<Vec<RekordboxTreeNode>, ErrorResponse> {
-    log::info!("[rekordbox] get_rekordbox_playlist_tree: manual_db_path={:?}", manual_db_path);
-    let rb_config = resolve_rekordbox_config(manual_db_path).map_err(|e| {
-        log::error!("[rekordbox] Config resolution failed: {} (code={})", e.message, e.code);
-        e
-    })?;
-    log::info!("[rekordbox] Config resolved: db_path={:?}", rb_config.db_path);
-    let db = database::RekordboxDatabase::open(&rb_config).map_err(|e| {
-        log::error!("[rekordbox] Database open failed: {}", e);
-        ErrorResponse::from(e)
-    })?;
-    log::info!("[rekordbox] Database opened successfully");
-    let nodes = playlist::get_playlist_tree(&db).map_err(|e| {
-        log::error!("[rekordbox] Playlist tree query failed: {}", e);
-        ErrorResponse::from(e)
-    })?;
-    log::info!("[rekordbox] Playlist tree loaded: {} nodes", nodes.len());
-    Ok(nodes)
+    let rb_config = resolve_rekordbox_config(manual_db_path)?;
+    let db = database::RekordboxDatabase::open(&rb_config).map_err(ErrorResponse::from)?;
+    playlist::get_playlist_tree(&db).map_err(ErrorResponse::from)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/rekordbox_export.rs
+++ b/src-tauri/src/commands/rekordbox_export.rs
@@ -221,7 +221,7 @@ pub async fn export_playlist_to_rekordbox(
             let infrabooth_folder = session.init_infrabooth_folder()?;
             log::info!("[rekordbox-export] InfraBooth folder initialized: id={}", infrabooth_folder.id);
 
-            let target_parent_id = parent_folder_id.as_deref().unwrap_or(&infrabooth_folder.id);
+            let target_parent_id = parent_folder_id.as_deref().unwrap_or("root");
 
             log::info!("[rekordbox-export] Finding/creating playlist '{}'...", playlist_name);
             let named_pl = session.find_or_create_playlist(&playlist_name, target_parent_id)?;

--- a/src-tauri/src/services/rekordbox/playlist.rs
+++ b/src-tauri/src/services/rekordbox/playlist.rs
@@ -233,7 +233,8 @@ pub fn list_playlists_in_folder(db: &RekordboxDatabase, parent_id: &str) -> Resu
 }
 
 pub fn get_playlist_tree(db: &RekordboxDatabase) -> Result<Vec<RekordboxTreeNode>, RekordboxError> {
-    let mut stmt = db.conn().prepare(PLAYLIST_SELECT).map_err(|e| RekordboxError::DatabaseError(format!("Playlist tree query failed: {}", e)))?;
+    let query = format!("{} WHERE Name IS NOT NULL", PLAYLIST_SELECT);
+    let mut stmt = db.conn().prepare(&query).map_err(|e| RekordboxError::DatabaseError(format!("Playlist tree query failed: {}", e)))?;
 
     let nodes = stmt
         .query_map([], |row| Ok(RekordboxTreeNode { id: row.get(0)?, name: row.get(2)?, attribute: row.get(3)?, parent_id: row.get(4)?, seq: row.get(1)? }))

--- a/src-tauri/src/services/rekordbox/playlist.rs
+++ b/src-tauri/src/services/rekordbox/playlist.rs
@@ -7,7 +7,8 @@ use crate::models::error::RekordboxError;
 
 const PLAYLIST_SELECT: &str = "\
     SELECT ID, Seq, Name, Attribute, ParentID \
-    FROM djmdPlaylist";
+    FROM djmdPlaylist \
+    WHERE rb_local_deleted = 0";
 
 fn row_to_playlist(row: &rusqlite::Row) -> rusqlite::Result<DjmdPlaylist> {
     Ok(DjmdPlaylist { id: row.get(0)?, seq: row.get(1)?, name: row.get(2)?, attribute: row.get(3)?, parent_id: row.get(4)? })
@@ -19,13 +20,13 @@ fn row_to_song(row: &rusqlite::Row) -> rusqlite::Result<DjmdSongPlaylist> {
 
 fn find_playlist_by_name_and_type(db: &RekordboxDatabase, name: &str, parent_id: &str, attribute: i32) -> Option<DjmdPlaylist> {
     db.conn()
-        .query_row(&format!("{} WHERE Name = ?1 AND Attribute = ?2 AND ParentID = ?3", PLAYLIST_SELECT), params![name, attribute, parent_id], row_to_playlist)
+        .query_row(&format!("{} AND Name = ?1 AND Attribute = ?2 AND ParentID = ?3", PLAYLIST_SELECT), params![name, attribute, parent_id], row_to_playlist)
         .ok()
 }
 
 fn count_siblings(db: &RekordboxDatabase, parent_id: &str) -> Result<i32, RekordboxError> {
     db.conn()
-        .query_row("SELECT COUNT(*) FROM djmdPlaylist WHERE ParentID = ?1", params![parent_id], |row| row.get(0))
+        .query_row("SELECT COUNT(*) FROM djmdPlaylist WHERE rb_local_deleted = 0 AND ParentID = ?1", params![parent_id], |row| row.get(0))
         .map_err(|e| RekordboxError::DatabaseError(format!("Count siblings failed: {}", e)))
 }
 
@@ -33,7 +34,7 @@ fn reorder_siblings(db: &mut RekordboxDatabase, parent_id: &str) -> Result<(), R
     let ids: Vec<String> = {
         let mut stmt = db
             .conn()
-            .prepare("SELECT ID FROM djmdPlaylist WHERE ParentID = ?1 ORDER BY Seq ASC")
+            .prepare("SELECT ID FROM djmdPlaylist WHERE rb_local_deleted = 0 AND ParentID = ?1 ORDER BY Seq ASC")
             .map_err(|e| RekordboxError::DatabaseError(format!("Reorder query failed: {}", e)))?;
 
         let ids = stmt
@@ -99,13 +100,13 @@ pub fn find_infrabooth_folder(db: &RekordboxDatabase) -> Option<DjmdPlaylist> {
 }
 
 pub fn find_playlist_by_id(db: &RekordboxDatabase, playlist_id: &str) -> Option<DjmdPlaylist> {
-    db.conn().query_row(&format!("{} WHERE ID = ?1", PLAYLIST_SELECT), params![playlist_id], row_to_playlist).ok()
+    db.conn().query_row(&format!("{} AND ID = ?1", PLAYLIST_SELECT), params![playlist_id], row_to_playlist).ok()
 }
 
 pub fn find_playlist_in_folder(db: &RekordboxDatabase, playlist_id: &str, parent_id: &str) -> Option<DjmdPlaylist> {
     db.conn()
         .query_row(
-            &format!("{} WHERE ID = ?1 AND ParentID = ?2 AND Attribute = ?3", PLAYLIST_SELECT),
+            &format!("{} AND ID = ?1 AND ParentID = ?2 AND Attribute = ?3", PLAYLIST_SELECT),
             params![playlist_id, parent_id, PLAYLIST_TYPE_PLAYLIST],
             row_to_playlist,
         )
@@ -132,14 +133,14 @@ pub fn create_playlist(db: &mut RekordboxDatabase, name: &str, parent_id: &str) 
     insert_playlist_row(db, &id, &final_name, PLAYLIST_TYPE_PLAYLIST, parent_id, seq)?;
 
     db.conn()
-        .query_row(&format!("{} WHERE ID = ?1", PLAYLIST_SELECT), params![id], row_to_playlist)
+        .query_row(&format!("{} AND ID = ?1", PLAYLIST_SELECT), params![id], row_to_playlist)
         .map_err(|e| RekordboxError::DatabaseError(format!("Playlist not found after insert: {}", e)))
 }
 
 pub fn delete_playlist(db: &mut RekordboxDatabase, playlist_id: &str) -> Result<(), RekordboxError> {
     let parent_id: String = db
         .conn()
-        .query_row("SELECT ParentID FROM djmdPlaylist WHERE ID = ?1", params![playlist_id], |row| row.get(0))
+        .query_row("SELECT ParentID FROM djmdPlaylist WHERE rb_local_deleted = 0 AND ID = ?1", params![playlist_id], |row| row.get(0))
         .map_err(|e| RekordboxError::DatabaseError(format!("Playlist not found for delete: {}", e)))?;
 
     db.conn()
@@ -220,7 +221,7 @@ pub fn find_playlist_by_name(db: &RekordboxDatabase, name: &str, parent_id: &str
 pub fn list_playlists_in_folder(db: &RekordboxDatabase, parent_id: &str) -> Result<Vec<DjmdPlaylist>, RekordboxError> {
     let mut stmt = db
         .conn()
-        .prepare(&format!("{} WHERE ParentID = ?1 AND Attribute = ?2 ORDER BY Seq ASC", PLAYLIST_SELECT))
+        .prepare(&format!("{} AND ParentID = ?1 AND Attribute = ?2 ORDER BY Seq ASC", PLAYLIST_SELECT))
         .map_err(|e| RekordboxError::DatabaseError(format!("List playlists query failed: {}", e)))?;
 
     let playlists = stmt
@@ -233,7 +234,7 @@ pub fn list_playlists_in_folder(db: &RekordboxDatabase, parent_id: &str) -> Resu
 }
 
 pub fn get_playlist_tree(db: &RekordboxDatabase) -> Result<Vec<RekordboxTreeNode>, RekordboxError> {
-    let query = format!("{} WHERE Name IS NOT NULL", PLAYLIST_SELECT);
+    let query = format!("{} AND Name IS NOT NULL", PLAYLIST_SELECT);
     let mut stmt = db.conn().prepare(&query).map_err(|e| RekordboxError::DatabaseError(format!("Playlist tree query failed: {}", e)))?;
 
     let nodes = stmt

--- a/src/features/download/hooks/useDownloadPipeline.ts
+++ b/src/features/download/hooks/useDownloadPipeline.ts
@@ -22,7 +22,7 @@ export function useDownloadPipeline(): PipelineView {
   const onDownloadAnother = useCallback(() => {
     useQueueStore.getState().clearQueue();
     flow.setUrl('');
-  }, [flow.setUrl]);
+  }, [flow]);
 
   if (completion.isComplete) {
     return { type: 'complete', completion, onDownloadAnother };

--- a/src/features/queue/hooks/useMediaInfoFetcher.ts
+++ b/src/features/queue/hooks/useMediaInfoFetcher.ts
@@ -47,7 +47,7 @@ export function useMediaInfoFetcher(): UseMediaInfoFetcherReturn {
     (url: string) => {
       mutation.mutate(url);
     },
-    [mutation.mutate]
+    [mutation]
   );
 
   const clear = useCallback(() => {
@@ -55,7 +55,7 @@ export function useMediaInfoFetcher(): UseMediaInfoFetcherReturn {
     setMediaInfo(null);
     setValidation(null);
     mutation.reset();
-  }, [mutation.reset]);
+  }, [mutation]);
 
   const error = useMemo(
     () => (mutation.error ? parseMediaError(mutation.error, t) : null),

--- a/src/features/rekordbox-export/__test__/useRekordboxExport.test.ts
+++ b/src/features/rekordbox-export/__test__/useRekordboxExport.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
 import type { TrackInfo, ExportResult } from '@/bindings';
 import { useRekordboxExport } from '../hooks/useRekordboxExport';
 
@@ -35,6 +37,14 @@ vi.mock('@/features/settings/store', () => ({
   },
 }));
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
 const mockTrack: TrackInfo = {
   id: 1,
   title: 'Test Track',
@@ -64,7 +74,7 @@ describe('useRekordboxExport', () => {
   });
 
   it('starts in idle phase', () => {
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     expect(result.current.phase).toBe('idle');
     expect(result.current.trackStatuses.size).toBe(0);
@@ -75,7 +85,7 @@ describe('useRekordboxExport', () => {
   });
 
   it('transitions to confirm phase on openConfirm', () => {
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     act(() => {
       result.current.openConfirm();
@@ -85,7 +95,7 @@ describe('useRekordboxExport', () => {
   });
 
   it('transitions back to idle on close', () => {
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     act(() => {
       result.current.openConfirm();
@@ -101,7 +111,7 @@ describe('useRekordboxExport', () => {
   it('transitions to complete on successful export', async () => {
     mockExportPlaylistToRekordbox.mockResolvedValue(mockResult);
 
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     await act(async () => {
       await result.current.startExport();
@@ -115,7 +125,7 @@ describe('useRekordboxExport', () => {
   it('passes maxConcurrent and null parentFolderId from settings store', async () => {
     mockExportPlaylistToRekordbox.mockResolvedValue(mockResult);
 
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     await act(async () => {
       await result.current.startExport();
@@ -130,12 +140,12 @@ describe('useRekordboxExport', () => {
   });
 
   it('starts with undefined selectedFolderId', () => {
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
     expect(result.current.selectedFolderId).toBeUndefined();
   });
 
   it('updates selectedFolderId via setSelectedFolderId', () => {
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     act(() => {
       result.current.setSelectedFolderId('folder-123');
@@ -147,7 +157,7 @@ describe('useRekordboxExport', () => {
   it('passes selectedFolderId to export API', async () => {
     mockExportPlaylistToRekordbox.mockResolvedValue(mockResult);
 
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     act(() => {
       result.current.setSelectedFolderId('folder-456');
@@ -168,7 +178,7 @@ describe('useRekordboxExport', () => {
   it('uses folderId override when passed to startExport', async () => {
     mockExportPlaylistToRekordbox.mockResolvedValue(mockResult);
 
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     await act(async () => {
       await result.current.startExport('override-folder');
@@ -185,7 +195,7 @@ describe('useRekordboxExport', () => {
   it('transitions to error on failed export', async () => {
     mockExportPlaylistToRekordbox.mockRejectedValue(new Error('Export failed'));
 
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     await act(async () => {
       await result.current.startExport();
@@ -201,7 +211,7 @@ describe('useRekordboxExport', () => {
     const { ApiError } = await import('@/lib/tauri');
     mockExportPlaylistToRekordbox.mockRejectedValue(new ApiError('REKORDBOX_RUNNING', 'Rekordbox is running'));
 
-    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'));
+    const { result } = renderHook(() => useRekordboxExport([mockTrack], 'Test Playlist'), { wrapper: createWrapper() });
 
     await act(async () => {
       await result.current.startExport();

--- a/src/features/rekordbox-export/hooks/useRekordboxExport.ts
+++ b/src/features/rekordbox-export/hooks/useRekordboxExport.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { useQueryClient } from '@tanstack/react-query';
 import type { TrackInfo, ExportResult, RekordboxExportProgressEvent, RekordboxExportStatus, DownloadProgressEvent } from '@/bindings';
 import { api, ApiError } from '@/lib/tauri';
 import { toTrackCore } from '@/lib/trackMapping';
@@ -39,6 +40,7 @@ export function useRekordboxExport(tracks: TrackInfo[] | undefined, playlistName
   const [selectedFolderId, setSelectedFolderId] = useState<string | null | undefined>(undefined);
   const unlistenRef = useRef<UnlistenFn[]>([]);
   const cancelledRef = useRef(false);
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     return () => {
@@ -105,6 +107,7 @@ export function useRekordboxExport(tracks: TrackInfo[] | undefined, playlistName
     try {
       const result = await api.exportPlaylistToRekordbox(trackCores, playlistName, effectiveFolder, maxConcurrent);
       setState((s) => ({ ...s, phase: 'complete', result }));
+      void queryClient.invalidateQueries({ queryKey: ['rekordbox-backups'] });
     } catch (err: unknown) {
       if (cancelledRef.current) return;
       const code = err instanceof ApiError ? err.code : null;
@@ -117,7 +120,7 @@ export function useRekordboxExport(tracks: TrackInfo[] | undefined, playlistName
       unlistenDownload();
       unlistenRef.current = [];
     }
-  }, [tracks, playlistName, selectedFolderId]);
+  }, [tracks, playlistName, selectedFolderId, queryClient]);
 
   return {
     ...state,


### PR DESCRIPTION
Rekordbox 7 databases contain ghost/deleted playlist entries with NULL Name, Attribute, and ParentID columns. Filter these out in the playlist tree query and add logging to the tree command for future debugging.