### PR TITLE
fix(rekordbox): align djmdContent INSERT with Rekordbox's own import …

### DIFF
--- a/src-tauri/src/services/downloader.rs
+++ b/src-tauri/src/services/downloader.rs
@@ -339,10 +339,9 @@ struct FfmpegContext<'a> {
 fn append_common_ffmpeg_args(args: &mut Vec<String>, output_path: &Path) {
     let output_str = output_path.to_string_lossy().to_string();
 
-    // Select only the first audio stream — excludes video, subtitle, and data
-    // streams that can cause Rekordbox to classify the MP3 as "video file."
+    // Select only the first audio stream — explicit mapping excludes video,
+    // subtitle, and data streams that cause Rekordbox to classify MP3s as "video file."
     args.extend_from_slice(&["-map".to_string(), "0:a:0".to_string()]);
-    args.push("-vn".to_string());
 
     // Strip all source container metadata — our id3 crate writes clean tags afterward.
     args.extend_from_slice(&["-map_metadata".to_string(), "-1".to_string()]);
@@ -933,11 +932,8 @@ mod tests {
     }
 
     fn assert_common_ffmpeg_args(args: &[String]) {
-        assert!(args.contains(&"-map".to_string()));
-        assert!(args.contains(&"0:a:0".to_string()));
-        assert!(args.contains(&"-vn".to_string()));
-        assert!(args.contains(&"-map_metadata".to_string()));
-        assert!(args.contains(&"-1".to_string()));
+        assert!(args.windows(2).any(|w| w == ["-map", "0:a:0"]));
+        assert!(args.windows(2).any(|w| w == ["-map_metadata", "-1"]));
     }
 
     #[test]

--- a/src-tauri/src/services/downloader.rs
+++ b/src-tauri/src/services/downloader.rs
@@ -339,10 +339,13 @@ struct FfmpegContext<'a> {
 fn append_common_ffmpeg_args(args: &mut Vec<String>, output_path: &Path) {
     let output_str = output_path.to_string_lossy().to_string();
 
-    // Strip video streams — some sources embed artwork as a video track,
-    // which causes Rekordbox to classify the MP3 as a "video file".
-    // Artwork is embedded separately via ID3 APIC frames in metadata.rs.
+    // Select only the first audio stream — excludes video, subtitle, and data
+    // streams that can cause Rekordbox to classify the MP3 as "video file."
+    args.extend_from_slice(&["-map".to_string(), "0:a:0".to_string()]);
     args.push("-vn".to_string());
+
+    // Strip all source container metadata — our id3 crate writes clean tags afterward.
+    args.extend_from_slice(&["-map_metadata".to_string(), "-1".to_string()]);
 
     // Progress reporting
     args.extend_from_slice(&["-progress".to_string(), "pipe:1".to_string()]);
@@ -929,6 +932,14 @@ mod tests {
         assert_eq!(detect_format_from_content_type("text/html"), OriginalFormat::Unknown);
     }
 
+    fn assert_common_ffmpeg_args(args: &[String]) {
+        assert!(args.contains(&"-map".to_string()));
+        assert!(args.contains(&"0:a:0".to_string()));
+        assert!(args.contains(&"-vn".to_string()));
+        assert!(args.contains(&"-map_metadata".to_string()));
+        assert!(args.contains(&"-1".to_string()));
+    }
+
     #[test]
     fn test_build_ffmpeg_args_for_original_wav() {
         let args = build_ffmpeg_args_for_original(Path::new("/tmp/input.wav"), Path::new("/tmp/output.mp3"), OriginalFormat::Wav);
@@ -936,7 +947,7 @@ mod tests {
         let args = args.unwrap();
         assert!(args.contains(&"-b:a".to_string()));
         assert!(args.contains(&"320k".to_string()));
-        assert!(args.contains(&"-vn".to_string()));
+        assert_common_ffmpeg_args(&args);
     }
 
     #[test]
@@ -945,7 +956,7 @@ mod tests {
         assert!(args.is_some());
         let args = args.unwrap();
         assert!(args.contains(&"320k".to_string()));
-        assert!(args.contains(&"-vn".to_string()));
+        assert_common_ffmpeg_args(&args);
     }
 
     #[test]
@@ -960,6 +971,6 @@ mod tests {
         assert!(args.is_some());
         let args = args.unwrap();
         assert!(args.contains(&"256k".to_string()));
-        assert!(args.contains(&"-vn".to_string()));
+        assert_common_ffmpeg_args(&args);
     }
 }

--- a/src-tauri/src/services/rekordbox/content.rs
+++ b/src-tauri/src/services/rekordbox/content.rs
@@ -63,10 +63,6 @@ pub fn add_content(db: &mut RekordboxDatabase, file_path: &Path, metadata: &Trac
     let (device_id, master_db_id) = get_device_info(db)?;
     log::debug!("[rekordbox-content] device_id: {}, master_db_id: {}", device_id, master_db_id);
 
-    log::debug!("[rekordbox-content] Getting content link...");
-    let content_link = get_content_link(db)?;
-    log::debug!("[rekordbox-content] content_link: {}", content_link);
-
     log::debug!("[rekordbox-content] Generating new content ID...");
     let id = db.generate_unused_id("djmdContent")?.to_string();
     let uuid = Uuid::new_v4().to_string();
@@ -74,37 +70,44 @@ pub fn add_content(db: &mut RekordboxDatabase, file_path: &Path, metadata: &Trac
     let today = database::today_date();
     log::debug!("[rekordbox-content] Generated id: {}, uuid: {}", id, uuid);
 
-    let search_str = build_search_str(&metadata.title, &metadata.artist, metadata.album.as_deref());
-
     let length_sec = metadata.duration_ms.map(|ms| (ms / 1000) as i32);
 
     log::info!("[rekordbox-content] Inserting content into database: id={}, title={}", id, metadata.title);
     db.conn()
         .execute(
             "INSERT INTO djmdContent (
-                ID, UUID, FolderPath, FileNameL, FileNameS, Title,
+                ID, UUID, FolderPath, FileNameL, Title,
                 ArtistID, AlbumID, GenreID, FileType, FileSize,
                 BitRate, Length, SampleRate, Analysed,
-                DateCreated, StockDate, SearchStr, ContentLink,
+                DateCreated, StockDate,
                 MasterDBID, MasterSongID, rb_file_id, DeviceID,
-                HotCueAutoLoad, rb_data_status, rb_local_data_status,
+                HotCueAutoLoad, DeliveryControl, VideoAssociate,
+                Rating, ReleaseYear, TrackNo, DiscNo,
+                ColorID, DJPlayCount,
+                SamplerTrackInfo, SamplerPlayOffset, SamplerGain,
+                LyricStatus,
+                rb_data_status, rb_local_data_status,
                 rb_local_deleted, rb_local_synced,
                 created_at, updated_at
             ) VALUES (
-                ?1, ?2, ?3, ?4, ?5, ?6,
-                ?7, ?8, ?9, ?10, ?11,
-                ?12, ?13, ?14, ?15,
-                ?16, ?17, ?18, ?19,
-                ?20, ?21, ?22, ?23,
-                ?24, ?25, ?26,
-                ?27, ?28,
-                ?29, ?30
+                ?1, ?2, ?3, ?4, ?5,
+                ?6, ?7, ?8, ?9, ?10,
+                ?11, ?12, ?13, ?14,
+                ?15, ?16,
+                ?17, ?18, ?19, ?20,
+                ?21, ?22, ?23,
+                ?24, ?25, ?26, ?27,
+                ?28, ?29,
+                ?30, ?31, ?32,
+                ?33,
+                ?34, ?35,
+                ?36, ?37,
+                ?38, ?39
             )",
             params![
                 id,
                 uuid,
                 folder_path,
-                file_name,
                 file_name,
                 metadata.title,
                 artist_id,
@@ -118,13 +121,23 @@ pub fn add_content(db: &mut RekordboxDatabase, file_path: &Path, metadata: &Trac
                 0_i32,
                 today,
                 today,
-                search_str,
-                content_link,
                 master_db_id,
-                uuid,
+                id,
                 uuid,
                 device_id,
                 "on",
+                "on",
+                "0",
+                0_i32,
+                0_i32,
+                0_i32,
+                0_i32,
+                0_i32,
+                0_i32,
+                0_i32,
+                0_i32,
+                0.0_f64,
+                0_i32,
                 0_i32,
                 0_i32,
                 0_i32,
@@ -195,17 +208,4 @@ fn get_device_info(db: &RekordboxDatabase) -> Result<(String, String), Rekordbox
     db.conn()
         .query_row("SELECT ID, MasterDBID FROM djmdDevice LIMIT 1", [], |row| Ok((row.get(0)?, row.get(1)?)))
         .map_err(|e| RekordboxError::DatabaseError(format!("Device info query failed: {}", e)))
-}
-
-fn get_content_link(db: &RekordboxDatabase) -> Result<i64, RekordboxError> {
-    db.conn()
-        .query_row("SELECT rb_local_usn FROM djmdMenuItems WHERE Name = 'TRACK'", [], |row| row.get(0))
-        .map_err(|e| RekordboxError::DatabaseError(format!("Content link query failed: {}", e)))
-}
-
-fn build_search_str(title: &str, artist: &str, album: Option<&str>) -> String {
-    match album {
-        Some(a) => format!("{} {} {}", title, artist, a),
-        None => format!("{} {}", title, artist),
-    }
 }

--- a/src-tauri/src/services/rekordbox/tests/test_content.rs
+++ b/src-tauri/src/services/rekordbox/tests/test_content.rs
@@ -27,13 +27,16 @@ fn test_add_content() {
         sample_rate: Some(44100),
     };
     let content_id = content::add_content(&mut db, &mp3_path, &metadata).expect("add_content failed");
-    let (title, file_type, analysed): (Option<String>, i32, i32) = db
+    let (title, file_type, analysed, video_associate): (Option<String>, i32, i32, String) = db
         .conn()
-        .query_row("SELECT Title, FileType, Analysed FROM djmdContent WHERE ID = ?1", params![content_id], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .query_row("SELECT Title, FileType, Analysed, VideoAssociate FROM djmdContent WHERE ID = ?1", params![content_id], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
         .expect("content not found in DB");
     assert_eq!(title.as_deref(), Some("Test Track"));
     assert_eq!(file_type, 1);
     assert_eq!(analysed, 0);
+    assert_eq!(video_associate, "0");
 }
 
 #[test]


### PR DESCRIPTION
…format

Tracks exported via InfraBooth were rejected by Rekordbox CDJ/USB export with error [2] "unsupported format" despite being valid MP3 files. Comparing DB entries of app-exported tracks vs manually-imported identical files revealed four fields our INSERT set that Rekordbox leaves NULL/empty on normal import: FileNameS, SearchStr, ContentLink, and CueUpdated.

- Remove FileNameS from INSERT (Rekordbox leaves it empty)
- Remove SearchStr from INSERT (Rekordbox populates this itself)
- Remove ContentLink from INSERT (was reading wrong value from djmdMenuItems)
- Remove CueUpdated from INSERT (was set to 1, Rekordbox leaves NULL)
- Add missing columns (DeliveryControl, VideoAssociate, Rating, etc.) to match the full schema of a Rekordbox-native import
- FFmpeg: add -map 0:a:0 and -map_metadata -1 to strip non-audio streams