### PR TITLE
feat(new-tracks): auto-refresh followed artists hourly

### DIFF
--- a/src/hooks/__test__/useAutoRefreshFollowedArtists.test.ts
+++ b/src/hooks/__test__/useAutoRefreshFollowedArtists.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAutoRefreshFollowedArtists } from '../useAutoRefreshFollowedArtists';
+import { FOLLOWED_ARTISTS_AUTO_REFRESH_MS } from '@/lib/query';
+import { createQueryWrapper } from '@/test/queryWrapper';
+
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }));
+
+vi.mock('@/bindings', () => ({
+  commands: {
+    getFollowedArtists: vi.fn().mockResolvedValue({ status: 'ok', data: [] }),
+  },
+}));
+
+describe('useAutoRefreshFollowedArtists', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not fire immediately on mount', async () => {
+    const { commands } = await import('@/bindings');
+    const getFollowedArtistsSpy = vi.mocked(commands.getFollowedArtists);
+
+    renderHook(() => useAutoRefreshFollowedArtists(true), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(getFollowedArtistsSpy).not.toHaveBeenCalled();
+  });
+
+  it('fires getFollowedArtists(true) after one interval', async () => {
+    const { commands } = await import('@/bindings');
+    const getFollowedArtistsSpy = vi.mocked(commands.getFollowedArtists);
+
+    renderHook(() => useAutoRefreshFollowedArtists(true), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await vi.advanceTimersByTimeAsync(FOLLOWED_ARTISTS_AUTO_REFRESH_MS);
+    expect(getFollowedArtistsSpy).toHaveBeenCalledTimes(1);
+    expect(getFollowedArtistsSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('fires again after a second interval', async () => {
+    const { commands } = await import('@/bindings');
+    const getFollowedArtistsSpy = vi.mocked(commands.getFollowedArtists);
+
+    renderHook(() => useAutoRefreshFollowedArtists(true), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await vi.advanceTimersByTimeAsync(FOLLOWED_ARTISTS_AUTO_REFRESH_MS);
+    await vi.advanceTimersByTimeAsync(FOLLOWED_ARTISTS_AUTO_REFRESH_MS);
+    expect(getFollowedArtistsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fire when enabled is false', async () => {
+    const { commands } = await import('@/bindings');
+    const getFollowedArtistsSpy = vi.mocked(commands.getFollowedArtists);
+
+    renderHook(() => useAutoRefreshFollowedArtists(false), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await vi.advanceTimersByTimeAsync(FOLLOWED_ARTISTS_AUTO_REFRESH_MS);
+    expect(getFollowedArtistsSpy).not.toHaveBeenCalled();
+  });
+
+  it('cleans up interval on unmount', async () => {
+    const { commands } = await import('@/bindings');
+    const getFollowedArtistsSpy = vi.mocked(commands.getFollowedArtists);
+
+    const { unmount } = renderHook(() => useAutoRefreshFollowedArtists(true), {
+      wrapper: createQueryWrapper(),
+    });
+
+    unmount();
+    await vi.advanceTimersByTimeAsync(FOLLOWED_ARTISTS_AUTO_REFRESH_MS);
+    expect(getFollowedArtistsSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useAutoRefreshFollowedArtists.ts
+++ b/src/hooks/useAutoRefreshFollowedArtists.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { logger } from '@/lib/logger';
+import { FOLLOWED_ARTISTS_AUTO_REFRESH_MS, refreshFollowedArtists } from '@/lib/query';
+
+export function useAutoRefreshFollowedArtists(enabled: boolean) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const interval = setInterval(() => {
+      void refreshFollowedArtists(queryClient).catch((error) =>
+        logger.error(`[new-tracks] Hourly auto-refresh failed: ${error}`),
+      );
+    }, FOLLOWED_ARTISTS_AUTO_REFRESH_MS);
+
+    return () => clearInterval(interval);
+  }, [enabled, queryClient]);
+}

--- a/src/hooks/useFollowedArtists.ts
+++ b/src/hooks/useFollowedArtists.ts
@@ -1,9 +1,9 @@
 import { useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '@/lib/tauri';
 import { logger } from '@/lib/logger';
 import { useIsSignedIn } from '@/features/auth/store';
-import { FOLLOWED_ARTISTS_KEY, DEFAULT_STALE_TIME } from '@/lib/query';
+import { FOLLOWED_ARTISTS_KEY, DEFAULT_STALE_TIME, refreshFollowedArtists } from '@/lib/query';
+import { api } from '@/lib/tauri';
 
 export function useFollowedArtists() {
   const isSignedIn = useIsSignedIn();
@@ -26,8 +26,7 @@ export function useFollowedArtists() {
 
   const refresh = useCallback(async () => {
     try {
-      const result = await api.getFollowedArtists(true);
-      queryClient.setQueryData([...FOLLOWED_ARTISTS_KEY], result);
+      await refreshFollowedArtists(queryClient);
     } catch (error) {
       void logger.error(`[new-tracks] Failed to refresh followed artists: ${error}`);
     }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,6 +1,15 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/tauri';
+
 export const DEFAULT_STALE_TIME = 5 * 60 * 1000;
 export const DEFAULT_GC_TIME = 10 * 60 * 1000;
 export const FOLLOWED_ARTISTS_KEY = ['followed-artists'] as const;
+export const FOLLOWED_ARTISTS_AUTO_REFRESH_MS = 60 * 60 * 1000;
 export const FOLLOW_STATUS_KEY = 'follow-status';
 export const LIKED_TRACKS_KEY = 'liked-tracks';
 export const LIBRARY_PLAYLISTS_KEY = 'library-playlists';
+
+export async function refreshFollowedArtists(queryClient: QueryClient) {
+  const result = await api.getFollowedArtists(true);
+  queryClient.setQueryData([...FOLLOWED_ARTISTS_KEY], result);
+}

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -7,6 +7,7 @@ import { useStartupAuth } from '@/features/auth/hooks/useStartupAuth';
 import { useInitializeSettings } from '@/features/settings/hooks/useInitializeSettings';
 import { useLikedTracks } from '@/features/library/hooks/useLikedTracks';
 import { useIsSignedIn } from '@/features/auth/store';
+import { useAutoRefreshFollowedArtists } from '@/hooks/useAutoRefreshFollowedArtists';
 
 interface AppProvidersProps {
   children: React.ReactNode;
@@ -24,6 +25,7 @@ function AppInitializer() {
   useStartupAuth();
   useInitializeSettings();
   useLikedTracks(isSignedIn);
+  useAutoRefreshFollowedArtists(isSignedIn);
   useUpdateCheck();
 
   return null;


### PR DESCRIPTION
Add an app-wide hourly auto-refresh of the followed-artists data powering the
new-releases and new-tracks carousels, on top of the existing manual refresh.

A new useAutoRefreshFollowedArtists hook (mounted in AppInitializer, gated on
sign-in) runs a fixed 1h setInterval that force-refreshes via a shared
refreshFollowedArtists helper, bypassing the backend in-memory cache so new
content is actually surfaced.
