### PR TITLE
feat(rekordbox): fermer Rekordbox depuis la modale d'export

### DIFF
--- a/src/features/library/components/PlaylistActionsDropdown.tsx
+++ b/src/features/library/components/PlaylistActionsDropdown.tsx
@@ -240,7 +240,17 @@ function CompletePhaseContent({
   );
 }
 
-function ErrorPhaseContent({ errorCode, onClose }: { errorCode: string | null; onClose: () => void }) {
+function ErrorPhaseContent({
+  errorCode,
+  onClose,
+  onQuitRekordbox,
+  isQuitting,
+}: {
+  errorCode: string | null;
+  onClose: () => void;
+  onQuitRekordbox: () => void;
+  isQuitting: boolean;
+}) {
   const { t } = useTranslation();
   return (
     <>
@@ -249,7 +259,13 @@ function ErrorPhaseContent({ errorCode, onClose }: { errorCode: string | null; o
         <DialogDescription className="text-destructive">{t(REKORDBOX_ERROR_KEYS[errorCode ?? ''] ?? 'common.error')}</DialogDescription>
       </DialogHeader>
       <DialogFooter>
-        <Button onClick={onClose}>{t('rekordboxExport.close')}</Button>
+        {errorCode === 'REKORDBOX_RUNNING' && (
+          <Button variant="outline" size="sm" disabled={isQuitting} onClick={onQuitRekordbox}>
+            {isQuitting && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+            {t('settings.backupCloseRekordbox')}
+          </Button>
+        )}
+        <Button onClick={onClose} disabled={isQuitting}>{t('rekordboxExport.close')}</Button>
       </DialogFooter>
     </>
   );
@@ -287,6 +303,8 @@ export function PlaylistActionsDropdown({
     startExport,
     cancel,
     close,
+    quitAndRetry,
+    isQuitting,
   } = useRekordboxExport(tracks, playlistName);
 
   const { data: treeData, isLoading: treeLoading, isError: treeError, retry: retryTree } = useRekordboxTree(phase === 'confirm');
@@ -390,6 +408,7 @@ export function PlaylistActionsDropdown({
         open={isOpen}
         onOpenChange={(open) => {
           if (!open) {
+            if (isQuitting) return;
             if (phase === 'exporting') cancel();
             else close();
           }
@@ -449,7 +468,7 @@ export function PlaylistActionsDropdown({
 
           {phase === 'complete' && result && <CompletePhaseContent result={result} groups={groups} onClose={close} />}
 
-          {phase === 'error' && <ErrorPhaseContent errorCode={errorCode} onClose={close} />}
+          {phase === 'error' && <ErrorPhaseContent errorCode={errorCode} onClose={close} onQuitRekordbox={quitAndRetry} isQuitting={isQuitting} />}
         </DialogContent>
       </Dialog>
 

--- a/src/features/library/components/PlaylistActionsDropdown.tsx
+++ b/src/features/library/components/PlaylistActionsDropdown.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Disc3, EllipsisVertical, ExternalLink, Heart, Link, Loader2, Pencil, Send, Trash2 } from 'lucide-react';
+import { AlertTriangle, Disc3, EllipsisVertical, ExternalLink, Heart, Link, Loader2, Pencil, Send, Trash2 } from 'lucide-react';
 import type { ExportResult, TrackInfo, RekordboxExportStatus } from '@/bindings';
 import { cn } from '@/lib/utils';
 import { useLinkActions } from '@/hooks/useLinkActions';
@@ -252,20 +252,28 @@ function ErrorPhaseContent({
   isQuitting: boolean;
 }) {
   const { t } = useTranslation();
+  const isRunning = errorCode === 'REKORDBOX_RUNNING';
   return (
     <>
       <DialogHeader>
-        <DialogTitle>{t('rekordboxExport.confirmTitle')}</DialogTitle>
-        <DialogDescription className="text-destructive">{t(REKORDBOX_ERROR_KEYS[errorCode ?? ''] ?? 'common.error')}</DialogDescription>
+        <DialogTitle>{t('rekordboxExport.errorTitle')}</DialogTitle>
+        <DialogDescription asChild>
+          <span className="flex items-start gap-3 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            {t(REKORDBOX_ERROR_KEYS[errorCode ?? ''] ?? 'common.error')}
+          </span>
+        </DialogDescription>
       </DialogHeader>
       <DialogFooter>
-        {errorCode === 'REKORDBOX_RUNNING' && (
-          <Button variant="outline" size="sm" disabled={isQuitting} onClick={onQuitRekordbox}>
-            {isQuitting && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+        <Button variant="outline" onClick={onClose} disabled={isQuitting}>
+          {t('rekordboxExport.close')}
+        </Button>
+        {isRunning && (
+          <Button disabled={isQuitting} onClick={onQuitRekordbox}>
+            {isQuitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {t('settings.backupCloseRekordbox')}
           </Button>
         )}
-        <Button onClick={onClose} disabled={isQuitting}>{t('rekordboxExport.close')}</Button>
       </DialogFooter>
     </>
   );
@@ -468,7 +476,9 @@ export function PlaylistActionsDropdown({
 
           {phase === 'complete' && result && <CompletePhaseContent result={result} groups={groups} onClose={close} />}
 
-          {phase === 'error' && <ErrorPhaseContent errorCode={errorCode} onClose={close} onQuitRekordbox={quitAndRetry} isQuitting={isQuitting} />}
+          {phase === 'error' && (
+            <ErrorPhaseContent errorCode={errorCode} onClose={close} onQuitRekordbox={quitAndRetry} isQuitting={isQuitting} />
+          )}
         </DialogContent>
       </Dialog>
 

--- a/src/features/library/components/__test__/PlaylistActionsDropdown.test.tsx
+++ b/src/features/library/components/__test__/PlaylistActionsDropdown.test.tsx
@@ -12,6 +12,7 @@ const mockStartExport = vi.fn();
 const mockCancel = vi.fn();
 const mockClose = vi.fn();
 const mockSetSelectedFolderId = vi.fn();
+const mockQuitAndRetry = vi.fn();
 
 type ExportPhase = 'idle' | 'confirm' | 'exporting' | 'complete' | 'error';
 
@@ -28,6 +29,8 @@ let hookReturn = {
   startExport: mockStartExport,
   cancel: mockCancel,
   close: mockClose,
+  quitAndRetry: mockQuitAndRetry,
+  isQuitting: false,
 };
 
 let mockDetectionData: RekordboxStatus | undefined = { found: true, version: '6', dbPath: '/fake', isRunning: false };
@@ -106,6 +109,8 @@ describe('PlaylistActionsDropdown', () => {
       startExport: mockStartExport,
       cancel: mockCancel,
       close: mockClose,
+      quitAndRetry: mockQuitAndRetry,
+      isQuitting: false,
     };
     mockTreeReturn = { data: undefined, isLoading: false, isError: false };
   });
@@ -267,6 +272,38 @@ describe('PlaylistActionsDropdown', () => {
     hookReturn.error = 'Rekordbox is running — close it before making changes';
     render(<PlaylistActionsDropdown tracks={[mockTrack]} playlistName="My Playlist" />);
     expect(screen.getByText('rekordboxRunning')).toBeInTheDocument();
+  });
+
+  it('shows Close Rekordbox button when errorCode is REKORDBOX_RUNNING', async () => {
+    const user = userEvent.setup();
+    hookReturn.phase = 'error';
+    hookReturn.errorCode = 'REKORDBOX_RUNNING';
+    hookReturn.error = 'Rekordbox is running';
+    render(<PlaylistActionsDropdown tracks={[mockTrack]} playlistName="My Playlist" />);
+    const quitBtn = screen.getByRole('button', { name: 'backupCloseRekordbox' });
+    expect(quitBtn).toBeInTheDocument();
+    await user.click(quitBtn);
+    expect(mockQuitAndRetry).toHaveBeenCalledOnce();
+  });
+
+  it('does not show Close Rekordbox button for other error codes', () => {
+    hookReturn.phase = 'error';
+    hookReturn.errorCode = 'UNKNOWN';
+    hookReturn.error = 'Something went wrong';
+    render(<PlaylistActionsDropdown tracks={[mockTrack]} playlistName="My Playlist" />);
+    expect(screen.queryByRole('button', { name: 'backupCloseRekordbox' })).not.toBeInTheDocument();
+  });
+
+  it('disables Close button while quitting Rekordbox', () => {
+    hookReturn.phase = 'error';
+    hookReturn.errorCode = 'REKORDBOX_RUNNING';
+    hookReturn.error = 'Rekordbox is running';
+    hookReturn.isQuitting = true;
+    render(<PlaylistActionsDropdown tracks={[mockTrack]} playlistName="My Playlist" />);
+    const closeBtn = screen.getByRole('button', { name: 'close' });
+    expect(closeBtn).toBeDisabled();
+    const quitBtn = screen.getByRole('button', { name: 'backupCloseRekordbox' });
+    expect(quitBtn).toBeDisabled();
   });
 
   it('shows translated fallback for unknown error codes', () => {

--- a/src/features/rekordbox-export/hooks/useRekordboxExport.ts
+++ b/src/features/rekordbox-export/hooks/useRekordboxExport.ts
@@ -38,8 +38,10 @@ const INITIAL_STATE: ExportState = {
 export function useRekordboxExport(tracks: TrackInfo[] | undefined, playlistName: string) {
   const [state, setState] = useState<ExportState>(INITIAL_STATE);
   const [selectedFolderId, setSelectedFolderId] = useState<string | null | undefined>(undefined);
+  const [isQuitting, setIsQuitting] = useState(false);
   const unlistenRef = useRef<UnlistenFn[]>([]);
   const cancelledRef = useRef(false);
+  const lastFolderIdRef = useRef<string | null>(null);
   const queryClient = useQueryClient();
 
   useEffect(() => {
@@ -104,6 +106,7 @@ export function useRekordboxExport(tracks: TrackInfo[] | undefined, playlistName
       const trackCores = tracks.map(toTrackCore);
       const maxConcurrent = useSettingsStore.getState().maxConcurrentDownloads;
       const effectiveFolder = folderId !== undefined ? folderId : (selectedFolderId ?? null);
+      lastFolderIdRef.current = effectiveFolder;
 
       try {
         const result = await api.exportPlaylistToRekordbox(trackCores, playlistName, effectiveFolder, maxConcurrent);
@@ -125,6 +128,15 @@ export function useRekordboxExport(tracks: TrackInfo[] | undefined, playlistName
     [tracks, playlistName, selectedFolderId, queryClient],
   );
 
+  const quitAndRetry = useCallback(() => {
+    setIsQuitting(true);
+    void api
+      .quitRekordbox()
+      .then(() => new Promise<void>((resolve) => setTimeout(resolve, 1500)))
+      .then(() => startExport(lastFolderIdRef.current))
+      .finally(() => setIsQuitting(false));
+  }, [startExport]);
+
   return {
     ...state,
     selectedFolderId,
@@ -133,5 +145,7 @@ export function useRekordboxExport(tracks: TrackInfo[] | undefined, playlistName
     startExport,
     cancel,
     close,
+    quitAndRetry,
+    isQuitting,
   };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -683,6 +683,7 @@
     "button": "Export to Rekordbox",
     "moreActions": "More actions",
     "confirmTitle": "Export to Rekordbox",
+    "errorTitle": "Export failed",
     "confirmMessage": "Export {{count}} tracks as \"{{playlist}}\" to Rekordbox?",
     "confirmNote": "Tracks will be downloaded to the app data directory and registered in Rekordbox.",
     "downloadingTracks": "Downloading tracks...",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -683,6 +683,7 @@
     "button": "Exporter vers Rekordbox",
     "moreActions": "Plus d'actions",
     "confirmTitle": "Exporter vers Rekordbox",
+    "errorTitle": "Échec de l'export",
     "confirmMessage": "Exporter {{count}} pistes sous \"{{playlist}}\" vers Rekordbox ?",
     "confirmNote": "Les pistes seront téléchargées dans le dossier de l'application et enregistrées dans Rekordbox.",
     "downloadingTracks": "Téléchargement des pistes...",


### PR DESCRIPTION
## Context
Quand Rekordbox est ouvert, l'export echoue et la modale affichait seulement un message demandant de le fermer manuellement, obligeant l'utilisateur a quitter l'app.

## Résumé
- Bouton "Fermer Rekordbox" dans l'erreur `REKORDBOX_RUNNING`
- Relance automatique de l'export apres fermeture