### PR TITLE
feat(selections): polling quotidien des sélections

### DIFF
--- a/src/features/selections/hooks/useSelections.ts
+++ b/src/features/selections/hooks/useSelections.ts
@@ -4,6 +4,7 @@ import { api } from '@/lib/tauri';
 import { useIsSignedIn } from '@/features/auth/store';
 
 const STALE_TIME = 60 * 60 * 1000; // 1 hour
+const ONE_DAY_MS = 24 * 60 * 60 * 1000; // 1 day
 
 export function useSelections() {
   const isSignedIn = useIsSignedIn();
@@ -13,6 +14,8 @@ export function useSelections() {
     queryFn: api.getSelections,
     enabled: isSignedIn,
     staleTime: STALE_TIME,
+    refetchInterval: ONE_DAY_MS,
+    refetchIntervalInBackground: true,
     retry: false,
   });
 }


### PR DESCRIPTION
## Context
Les sélections curées n'avaient aucun rafraîchissement en arrière-plan, contrairement aux notifications et aux messages privés.

## Résumé
- Rafraîchissement quotidien des sélections, même fenêtre inactive